### PR TITLE
Rails4: Return an array when executing the report query

### DIFF
--- a/lib/compendium/query.rb
+++ b/lib/compendium/query.rb
@@ -142,7 +142,7 @@ module Compendium
     end
 
     def execute_query(command)
-      ::ActiveRecord::Base.connection.select_all(command)
+      ::ActiveRecord::Base.connection.select_all(command).to_a
     end
 
     def arg_is_report?(arg)

--- a/spec/count_query_spec.rb
+++ b/spec/count_query_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'compendium'
 require 'compendium/count_query'
+require 'active_support/core_ext'
 
 class SingleCounter
   def count


### PR DESCRIPTION
- Make sure the results are returned in an array like before, not ActiveRecord::Result
- Make sure tests are passing